### PR TITLE
Better formatting

### DIFF
--- a/src/exchange.py
+++ b/src/exchange.py
@@ -113,7 +113,11 @@ class ExchangeRates():
             for destination in destinations:
                 rate = self.rate(destination) / self.rate(source)
                 convertedAmount = rate * amount
-                formatted = '{0:.8f}'.format(convertedAmount).rstrip('0').rstrip('.')
+                if amount == 1:
+                	formatted = '{:,.8f}'.format(convertedAmount).rstrip('0').rstrip('.')
+                else:
+                	formatted = '{:,.2f}'.format(convertedAmount).rstrip('0').rstrip('.')
+
                 result = {
                     'amount': convertedAmount,
                     'source': source,


### PR DESCRIPTION
Use the popular format: `10,000,000.23` instead of `10000000.23456789`
The dot make it easier to read, and no currency worth so much that a 0.001 of an unit is meaningful thus keeping only 2 digit after decimal point.